### PR TITLE
Update network setting when it is empty

### DIFF
--- a/pkg/controller/vlan/bridge_vlan_controller.go
+++ b/pkg/controller/vlan/bridge_vlan_controller.go
@@ -82,8 +82,13 @@ func (c *BridgeVLANController) OnChange(key string, setting *harvesterv1.Setting
 		return nil, fmt.Errorf("encode network settings failed, error: %w, networksettings: %+v", err, networkSetting)
 	}
 
-	harvesterv1.SettingConfigured.True(settingCopy)
+	if networkSetting.NIC == "" {
+		harvesterv1.SettingConfigured.False(settingCopy)
+	} else {
+		harvesterv1.SettingConfigured.True(settingCopy)
+	}
 	harvesterv1.SettingConfigured.Reason(settingCopy, "")
+
 	// update setting will trigger another reconcile
 	return c.settingClient.Update(settingCopy)
 }


### PR DESCRIPTION
**Problem:**
When the network-setting is reset to an empty value the configured status is still showing as `true`

**Solution:**
update the configured status according to the input NIC value

https://github.com/rancher/harvester-network-controller/issues/11