### PR TITLE
fix: connmanctl config nameservers and ipv4

### DIFF
--- a/pkg/bridge/link.go
+++ b/pkg/bridge/link.go
@@ -84,7 +84,7 @@ func (l *Link) DelBridgeVlan(vid uint16) error {
 
 const (
 	defaultRetryTimes = 10
-	defaultRetryInterval = 200 * time.Microsecond
+	defaultRetryInterval = time.Second
 )
 
 func (l *Link) setNoMaster() error {

--- a/pkg/controller/vlan/bridge_vlan_controller.go
+++ b/pkg/controller/vlan/bridge_vlan_controller.go
@@ -182,7 +182,7 @@ func (c *BridgeVLANController) configBridgeNetwork(setting *NetworkSetting) erro
 	// - No, make bridge return addresses to configured nic, lend addresses to bridge, return.
 	if nic.Attrs().MasterIndex != c.bridge.Index {
 		klog.Infof("configure network because the master of nic %s is not bridge %s", nic.Attrs().Name, c.bridge.Name)
-		if configuredNIC != nil {
+		if configuredNIC != nil &&  setting.NIC != setting.ConfiguredNIC {
 			if err := c.bridge.ReturnAddr(configuredNIC, vidList); err != nil {
 				klog.Errorf("return address failed, error: %v, NIC: %s", err, setting.ConfiguredNIC)
 			}

--- a/pkg/dhcp/connman_dhcp.go
+++ b/pkg/dhcp/connman_dhcp.go
@@ -15,14 +15,15 @@ import (
 
 const (
 	// keep --ipv4 to the end to avoid empty gateway configuration
-	configDHCPCmd     = "connmanctl config %s --nameservers 8.8.8.8 --ipv4 %s"
-	getIPv4ConfigCmd  = "connmanctl services %s"
-	ipv4ConfigKeyword = "IPv4.Configuration"
-	ipv4MethodKeyword = "Method"
-	ipv4Keyword       = "IPv4 = "
-	addrKeyword       = "Address"
-	maskKeyword       = "Netmask"
-	gatewayKeyword    = "Gateway"
+	configDHCPCmd        = "connmanctl config %s --ipv4 %s"
+	configNameserversCmd = "connmanctl config %s --nameservers 8.8.8.8"
+	getIPv4ConfigCmd     = "connmanctl services %s"
+	ipv4ConfigKeyword    = "IPv4.Configuration"
+	ipv4MethodKeyword    = "Method"
+	ipv4Keyword          = "IPv4 = "
+	addrKeyword          = "Address"
+	maskKeyword          = "Netmask"
+	gatewayKeyword       = "Gateway"
 
 	// IPv4 mode
 	Off    = "off"
@@ -47,10 +48,6 @@ func NewConnmanService(iface, hwaddr string) *ConnmanService {
 // ConfigIPv4 with connmanctl
 func (c *ConnmanService) configIPv4(mode string, args ...string) error {
 	if mode == Static {
-		if len(args) != 3 {
-			return fmt.Errorf("config manual mode should have 3 arguments, followed by address, netmask and gateway")
-		}
-
 		for _, arg := range args {
 			mode += " "
 			mode += arg
@@ -72,6 +69,7 @@ func (c *ConnmanService) configIPv4(mode string, args ...string) error {
 	}
 
 	statement := fmt.Sprintf(configDHCPCmd, c.service, mode)
+	klog.Infof("statement: %s", statement)
 	out, err := exec.Command("sh", "-c", statement).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("execute connmanctl config failed, error: %w, cmd: %s", err, statement)
@@ -80,8 +78,18 @@ func (c *ConnmanService) configIPv4(mode string, args ...string) error {
 		return fmt.Errorf("execute connmanctl config failed, stderr: [%s], cmd: %s", out, statement)
 	}
 
-	// wait for becoming effective
-	time.Sleep(waitEffectiveTime)
+	return nil
+}
+
+func (c *ConnmanService) configNameservers() error {
+	statement := fmt.Sprintf(configNameserversCmd, c.service)
+	out, err := exec.Command("sh", "-c", statement).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("execute connmanctl config failed, error: %w, cmd: %s", err, statement)
+	}
+	if len(out) != 0 {
+		return fmt.Errorf("execute connmanctl config failed, stderr: [%s], cmd: %s", out, statement)
+	}
 
 	return nil
 }
@@ -94,11 +102,33 @@ func (c *ConnmanService) DHCP2Static() error {
 
 	addr, mask, gw := getIPv4Addr(out)
 
-	return c.configIPv4(Static, addr, mask, gw)
+	if err := c.configIPv4(Static, addr, mask, gw); err != nil {
+		return err
+	}
+
+	if err := c.configNameservers(); err != nil {
+		return err
+	}
+
+	// wait for becoming effective
+	time.Sleep(waitEffectiveTime)
+
+	return nil
 }
 
 func (c *ConnmanService) ToDHCP() error {
-	return c.configIPv4(DHCP)
+	if err :=  c.configIPv4(DHCP); err != nil {
+		return err
+	}
+
+	if err :=  c.configNameservers(); err != nil {
+		return err
+	}
+
+	// wait for becoming effective
+	time.Sleep(waitEffectiveTime)
+
+	return nil
 }
 
 // GetIPv4Config with connmanctl


### PR DESCRIPTION
**issue**: https://github.com/rancher/harvester-network-controller/issues/14
- fix: connmanctl config nameservers and ipv4
- optimization: do not need to return address if NIC equals configured NIC